### PR TITLE
Remove base app plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,5 +70,4 @@ Create a `assets.json` file:
 
 ## Extras
 
-* *AssetVersions.baseAppPlugin* – for use with `@hdsydsvenskan/base-web-app`
 * *AssetVersions.webpackManifestPluginGenerate* – a `generate` method for use with [webpack-manifest-plugin](https://www.npmjs.com/package/webpack-manifest-plugin) to generate manifest with dependencies

--- a/index.js
+++ b/index.js
@@ -194,26 +194,6 @@ class AssetVersions {
   }
 }
 
-/**
- * Internal plugin definition for @Sydsvenskan
- *
- * @param {object} baseAppInstance
- * @param {AssetVersionsOptions} [options]
- * @returns {{ pluginName: 'AssetVersions', main: AssetVersions }}
- */
-AssetVersions.baseAppPlugin = function (baseAppInstance, options) {
-  options = Object.assign({
-    assetDefinitions: require('pkg-dir').sync(__dirname) + '/assets.json',
-    // @ts-ignore
-    useVersionedPaths: baseAppInstance.getConfig().env !== 'development'
-  }, options || {});
-
-  return {
-    pluginName: 'AssetVersions',
-    main: new AssetVersions(options)
-  };
-};
-
 AssetVersions.webpackManifestPluginGenerate = require('./lib/manifest-generator');
 AssetVersions.ASSET_VERSIONS_FILE_VERSION = ASSET_VERSIONS_FILE_VERSION;
 

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "dashdash": "^2.0.0",
     "debug": "^4.1.1",
     "load-json-file": "^6.2.0",
-    "pkg-dir": "^5.0.0",
     "rev-file": "^3.0.0",
     "type-fest": "^0.16.0",
     "verror": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3107,7 +3107,7 @@ find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-up@5.0.0, find-up@^5.0.0:
+find-up@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -5150,13 +5150,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-dir@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
-  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
-  dependencies:
-    find-up "^5.0.0"
 
 pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Since the `baseApp` architecture is being removed from the originating architecture, it no longer makes sense to maintain compatibility in this lib.