### PR TITLE
Webpack multi compiler (and watch) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 CLI and helper methods for asset versioning. Includes support for Webpack chunking.
 
+* Minimum supported Node version is v14
+* Minimum supported Webpack version is v4.44.0
+
 ## Installation
 
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -44,7 +44,7 @@ const options = [
   {
     names: ['source-maps', 's'],
     type: 'bool',
-    help: 'Include source-map entries when adding WebPack files',
+    help: 'Include source-map entries when adding Webpack files',
     'default': false
   }
 ];

--- a/lib/manifest-generator.js
+++ b/lib/manifest-generator.js
@@ -19,20 +19,33 @@
  */
 const webpackManifestPluginGenerate = (seed, files) => {
   /** @type {AssetVersionsWebpackManifest} */
-  const manifest = Object.assign({}, seed);
+  const manifest = (seed || {});
+
+  /** @type {string[]} Built list of files affected in this set of files */
+  const manifestFiles = [];
 
   for (const { name, chunk, path } of files) {
-    if (!name || !chunk || !chunk.groupsIterable) {
+    if (!name || !chunk || !chunk?.groupsIterable) {
       continue;
     }
+    // List this file as "tracked" being part of this manifest
+    manifestFiles.push(name);
 
     const chunkGroups = chunk.groupsIterable;
-    const isMap = name.slice(-4) === `.map`;
+    const isMap = (/** @type {string} */ name) => name.slice(-4) === `.map`;
 
-    manifest[name] = {
-      path,
-      siblings: isMap ? undefined : []
-    };
+    if (manifest[name]) {
+      if (!manifest[name].siblings) {
+        manifest[name].siblings = isMap(name) ? undefined : [];
+      }
+      // Path might have change, e.g. watching files.
+      manifest[name].path = path;
+    } else {
+      manifest[name] = {
+        path,
+        siblings: isMap(name) ? undefined : []
+      };
+    }
 
     for (const chunkGroup of chunkGroups) {
       const files = [];
@@ -42,29 +55,27 @@ const webpackManifestPluginGenerate = (seed, files) => {
       }
 
       for (const filename of files) {
-        if (!isMap && filename !== path && filename.slice(-4) !== `.map`) {
+        // Ignore maps and the current file when it comes to finding siblings:
+        if (!isMap(name) && filename !== path && !isMap(filename)) {
           const siblings = manifest[name].siblings;
-          if (siblings) siblings.push(filename);
+          if (Array.isArray(siblings)) {
+            siblings.push(filename);
+          }
         }
       }
     }
   }
 
-  const manifestFiles = Object.keys(manifest);
-
   for (const key of manifestFiles) {
     const item = manifest[key];
 
-    if (item.siblings) {
-      /** @type {string[]} */
-      const resolvedSiblings = [];
-
-      for (const sibling of item.siblings) {
-        const matchingFile = manifestFiles.find(matchKey => manifest[matchKey].path.endsWith(sibling));
-        if (matchingFile !== undefined) resolvedSiblings.push(matchingFile);
-      }
-
-      item.siblings = resolvedSiblings;
+    if (Array.isArray(item.siblings)) {
+      // Replace siblings files (incl. hash) with list of resolved file name (sans hash)
+      item.siblings = item.siblings.map(sibling => {
+        return manifestFiles.find(matchKey => {
+          return manifest[matchKey]?.path?.endsWith(sibling);
+        }) || '';
+      }).filter(item => Boolean(item));
     }
   }
 

--- a/test/webpack-manifest-plugin-generate.spec.js
+++ b/test/webpack-manifest-plugin-generate.spec.js
@@ -22,4 +22,26 @@ describe('webpackManifestPluginGenerate()', () => {
       foo: { path: '123' }
     });
   });
+
+  it('should update path when seed already contains entry (watch/multi-compiler)', function () {
+    // Represents already built file per "foo" entry
+    const seed = {
+      'myfile.js': { path: 'myfile.123.js' }
+    };
+    // New build affecting same file, but with new path for "foo"
+    const files = [
+      {
+        chunk: {
+          groupsIterable: []
+        },
+        path: 'myfile.234.js',
+        name: 'myfile.js',
+      }
+    ];
+    // @ts-ignore due to not acutally using the FileDescriptor signaruture
+    const result = webpackManifestPluginGenerate(seed, files);
+    result.should.deep.equal({
+      'myfile.js': { path: 'myfile.234.js', siblings: [] }
+    });
+  });
 });


### PR DESCRIPTION
When running either multi-compiler (where one webpack config is actually an array of different configs, that might output to the same manifest file) we need to share a seed object between builds.

When watching, the same seed will be used between builds.

Previously, the seed wasn't shared, so we were missing multi-compiler support. In this PR, the seed is shared properly, but then we need to update references to paths as files are updated.